### PR TITLE
Removed json suffix from grape initializer

### DIFF
--- a/api/config/initializers/grape.rb
+++ b/api/config/initializers/grape.rb
@@ -1,3 +1,3 @@
-GrapeSwaggerRails.options.url = "/api/v1/swagger_doc.json"
+GrapeSwaggerRails.options.url = "/api/v1/swagger_doc"
 GrapeSwaggerRails.options.app_name = "Biznz"
 GrapeSwaggerRails.options.app_url = "http://localhost:3000"


### PR DESCRIPTION
Recent updates of `grape 0.11.0` and `grape-swagger 0.10.1` break the initializer in `config/initializers/grape.rb`.     

When accessing the documentation, it now returns an error: 
    
    Unable to read api 'contacts' from path 
    http://localhost:3000/api/v1/swagger_doc.json/contacts (server returned undefined)   

The .format suffix needs to be removed from `GrapeSwagger.options.url`, which becomes 
```
GrapeSwaggerRails.options.url = '/api/v1/swagger_doc'
``` 

Here is a link to the bug report:
```
https://github.com/tim-vandecasteele/grape-swagger/issues/187
```
and the answer was originally given by `@dblock`.